### PR TITLE
feat(confluence): add page move support

### DIFF
--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -537,6 +537,7 @@ class PagesMixin(ConfluenceClient):
             True if the page was moved successfully, False otherwise
 
         Raises:
+            ValueError: If space_key is not provided and cannot be resolved
             Exception: If there is an error moving the page
         """
         try:
@@ -564,6 +565,9 @@ class PagesMixin(ConfluenceClient):
                 position=move_position,
             )
             return True
+        except ValueError as e:
+            logger.error(f"Error moving page {page_id}: {str(e)}")
+            raise
         except Exception as e:
             logger.error(f"Error moving page {page_id}: {str(e)}")
             raise Exception(f"Failed to move page {page_id}: {str(e)}") from e

--- a/src/mcp_atlassian/confluence/v2_adapter.py
+++ b/src/mcp_atlassian/confluence/v2_adapter.py
@@ -340,6 +340,48 @@ class ConfluenceV2Adapter:
             logger.error(f"Error getting page '{page_id}': {e}")
             raise ValueError(f"Failed to get page '{page_id}': {e}") from e
 
+    def move_page(
+        self,
+        page_id: str,
+        space_key: str,
+        parent_id: str | None = None,
+        position: str = "append",
+    ) -> bool:
+        """Move a page using the v2 API.
+
+        Args:
+            page_id: The ID of the page to move
+            space_key: Destination space key
+            parent_id: Destination parent page ID (optional)
+            position: Position relative to the parent (default: "append")
+
+        Returns:
+            True if the page was moved successfully, False otherwise
+
+        Raises:
+            ValueError: If the move operation fails
+        """
+        try:
+            space_id = self._get_space_id(space_key)
+            data: dict[str, Any] = {"spaceId": space_id, "position": position}
+            if parent_id:
+                data["parentId"] = parent_id
+
+            url = f"{self.base_url}/api/v2/pages/{page_id}/move"
+            response = self.session.post(url, json=data)
+            response.raise_for_status()
+
+            logger.debug(f"Successfully moved page '{page_id}' with v2 API")
+            return True
+        except HTTPError as e:
+            logger.error(f"HTTP error moving page '{page_id}': {e}")
+            if e.response is not None:
+                logger.error(f"Response content: {e.response.text}")
+            raise ValueError(f"Failed to move page '{page_id}': {e}") from e
+        except Exception as e:
+            logger.error(f"Error moving page '{page_id}': {e}")
+            raise ValueError(f"Failed to move page '{page_id}': {e}") from e
+
     def delete_page(self, page_id: str) -> bool:
         """Delete a page using the v2 API.
 

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -629,6 +629,25 @@ class TestPagesMixin:
         )
         assert result is True
 
+    def test_move_page_to_space_root(self, pages_mixin):
+        """Test moving a page to the space root."""
+        # Arrange
+        page_id = "987654321"
+        space_key = "DEMO"
+        pages_mixin.confluence.move_page.return_value = True
+
+        # Act
+        result = pages_mixin.move_page(page_id, space_key=space_key)
+
+        # Assert
+        pages_mixin.confluence.move_page.assert_called_once_with(
+            space_key=space_key,
+            page_id=page_id,
+            target_id=None,
+            position="topLevel",
+        )
+        assert result is True
+
     def test_move_page_error(self, pages_mixin):
         """Test error handling when moving a page."""
         # Arrange
@@ -639,6 +658,13 @@ class TestPagesMixin:
         # Act / Assert
         with pytest.raises(Exception, match="Failed to move page"):
             pages_mixin.move_page(page_id, space_key=space_key)
+
+    def test_move_page_missing_space_key_raises_value_error(self, pages_mixin):
+        """Test that ValueError is raised when space_key is missing."""
+        page_id = "987654321"
+        pages_mixin.confluence.get_page_by_id.return_value = {}
+        with pytest.raises(ValueError, match="space_key.*provided"):
+            pages_mixin.move_page(page_id)
 
     def test_get_page_success(self, pages_mixin):
         """Test successful page retrieval."""


### PR DESCRIPTION
## Summary
- allow moving Confluence pages between spaces and parents
- support page moves via Confluence v2 API for OAuth setups
- test page moves for standard and OAuth clients

## Testing
- `uv run pre-commit run --all-files`
- `uv run pytest --ignore=tests/test_real_api_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68a43841c36c8320880801881c182f3b

## Summary by Sourcery

Add support for moving Confluence pages between spaces and parent pages using both v1 and v2 APIs, with proper error handling and logging

New Features:
- Introduce move_page method in the Confluence pages client to relocate pages across spaces and parent pages
- Add move_page implementation in the Confluence v2 adapter for OAuth authenticated clients

Enhancements:
- Improve error handling and logging for page move operations

Tests:
- Add unit tests for moving pages with explicit space and parent, default space resolution, and error cases
- Add unit test verifying OAuth clients use the v2 API for page move actions