### PR TITLE
feat(confluence): update attach_file method to emphasize base64 conte…

### DIFF
--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -818,10 +818,12 @@ async def attach_file(
         str | None,
         Field(
             description=(
-                "Base64-encoded content of the file to attach. "
+                "**PRIMARY METHOD**: Base64-encoded content of the file to attach. "
+                "This is the RECOMMENDED approach for uploading files. "
                 "Since the MCP server runs in Docker and cannot access host files, "
-                "you must provide the file content encoded as base64 string. "
-                "Use this parameter instead of file_path."
+                "you MUST use this parameter. Read the file from your system and "
+                "encode it to base64 before passing it here. "
+                "DO NOT use file_path - it will not work in Docker."
             ),
             default=None,
         ),
@@ -830,9 +832,10 @@ async def attach_file(
         str | None,
         Field(
             description=(
-                "**DEPRECATED**: Path to the file on the local filesystem. "
-                "This parameter is deprecated because the MCP server runs in Docker "
-                "and cannot access host file paths. Use file_content_base64 instead."
+                "**DEPRECATED - DO NOT USE**: Path to file on local filesystem. "
+                "This parameter is deprecated and WILL NOT WORK because the MCP "
+                "server runs in Docker and cannot access host file paths. "
+                "Use file_content_base64 instead."
             ),
             default=None,
             deprecated=True,
@@ -892,14 +895,31 @@ async def attach_file(
 ) -> str:
     """Upload a file as an attachment to a Confluence page.
 
-    Since the MCP server runs in Docker, this tool accepts base64-encoded file content
-    instead of file paths. The client must read the file and encode it as base64.
+    **RECOMMENDED APPROACH**: Use file_content_base64 parameter with
+    base64-encoded file content. This is the primary and preferred method
+    since the MCP server runs in Docker and cannot access host file paths.
+
+    The file_path parameter is deprecated and should only be used for
+    backward compatibility in non-Docker environments. Always try
+    file_content_base64 first.
+
+    Workflow:
+        1. Read the file from your local system
+        2. Encode the file content to base64 string
+        3. Pass the base64 string via file_content_base64 parameter
+        4. Specify the filename (with extension) to determine the file type
 
     Args:
         ctx: The FastMCP context.
-        filename: Name of the file (used to determine extension and default name).
-        file_content_base64: Base64-encoded content of the file (preferred).
-        file_path: **DEPRECATED** - Local file path (won't work in Docker).
+        filename: Name of the file (used to determine extension and
+            default name).
+        file_content_base64: **RECOMMENDED** - Base64-encoded content of
+            the file. This is the primary method for file uploads. The
+            client must read the file and encode it as base64 before
+            calling this tool.
+        file_path: **DEPRECATED** - Local file path. This parameter is
+            deprecated and will not work when the MCP server runs in
+            Docker. Use file_content_base64 instead.
         page_id: ID of the page to attach the file to.
         space_key: Key of the space (used with title).
         title: Title of the target page (used with space_key).
@@ -912,7 +932,23 @@ async def attach_file(
 
     Raises:
         ValueError: If neither page_id nor space_key/title pair is provided,
-            or if base64 decoding fails, or if Confluence client is unavailable.
+            or if base64 decoding fails, or if Confluence client is
+            unavailable.
+
+    Example:
+        To upload a file, first encode it to base64:
+        ```python
+        import base64
+        with open('document.pdf', 'rb') as f:
+            content_base64 = base64.b64encode(f.read()).decode('utf-8')
+
+        # Then call the tool with file_content_base64
+        result = attach_file(
+            filename='document.pdf',
+            file_content_base64=content_base64,
+            page_id='123456'
+        )
+        ```
     """
     import base64
 


### PR DESCRIPTION
This pull request improves the documentation and parameter descriptions for the `attach_file` function in `src/mcp_atlassian/servers/confluence.py`. The changes clarify that using the `file_content_base64` parameter is the recommended and primary method for file uploads, while the `file_path` parameter is deprecated and will not work in Docker environments. The updates also provide a clear workflow and an example for users.

**Documentation and parameter description improvements:**

* Strongly emphasized that `file_content_base64` is the primary and recommended method for uploading files, and provided detailed instructions and warnings against using `file_path` in Docker environments. [[1]](diffhunk://#diff-21eda967acc9e34a2c66c3d648a774973d61936231bb4890f304cad216db449aL821-R826) [[2]](diffhunk://#diff-21eda967acc9e34a2c66c3d648a774973d61936231bb4890f304cad216db449aL833-R838)
* Expanded the docstring to explain the preferred workflow for file uploads, clarified the deprecation of `file_path`, and explained the reasoning behind these recommendations.
* Added a usage example demonstrating how to encode a file to base64 and call the function, making it easier for users to follow best practices.…nt usage and deprecate file_path parameter

<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

Fixes: #

## Changes

<!-- Briefly list the key changes made. -->

-
-
-

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [ ] Unit tests added/updated
- [ ] Integration tests passed
- [ ] Manual checks performed: `[briefly describe]`

## Checklist

- [ ] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [ ] All tests pass locally.
- [ ] Documentation updated (if needed).

## Summary by Sourcery

Clarify the attach_file API by marking base64 content as the recommended input, deprecating file path usage, and enriching documentation with workflow guidance and an example.

Enhancements:
- Emphasize file_content_base64 as the primary upload method and deprecate file_path in the attach_file function
- Expand the attach_file docstring with a clear workflow, detailed parameter descriptions, and Docker compatibility warnings
- Include a usage example showing how to encode a file to base64 before calling attach_file